### PR TITLE
Remove unused menu command factory parameters

### DIFF
--- a/Flashcards/Extensions/EnumExtensions.cs
+++ b/Flashcards/Extensions/EnumExtensions.cs
@@ -9,24 +9,6 @@ namespace Flashcards.Extensions;
 public static class EnumExtensions
 {
     /// <summary>
-    /// Retrieves the display name of an enum value using DisplayAttribute.
-    /// If the display name is not defined, the name of the enum value is returned.
-    /// </summary>
-    /// <typeparam name="TEntry">The type of the enum</typeparam>
-    /// <param name="enumValue">The enum value</param>
-    /// <returns>The display name of the enum value</returns>
-    public static string GetDisplayName<TEntry>(this TEntry enumValue) where TEntry : Enum
-    {
-        var displayName = enumValue.GetType()
-            .GetMember(enumValue.ToString())
-            .FirstOrDefault()?
-            .GetCustomAttribute<DisplayAttribute>()?
-            .GetName();
-
-        return displayName ?? enumValue.ToString();
-    }
-
-    /// <summary>
     /// Retrieves the display names of the enum values.
     /// </summary>
     /// <typeparam name="TEntry">The type of enum.</typeparam>
@@ -45,5 +27,23 @@ public static class EnumExtensions
     public static TEntry GetValueFromDisplayName<TEntry>(this string displayName) where TEntry : Enum
     {
         return Enum.GetValues(typeof(TEntry)).Cast<TEntry>().First(e => e.GetDisplayName() == displayName);
+    }
+    
+    /// <summary>
+    /// Retrieves the display name of an enum value using DisplayAttribute.
+    /// If the display name is not defined, the name of the enum value is returned.
+    /// </summary>
+    /// <typeparam name="TEntry">The type of the enum</typeparam>
+    /// <param name="enumValue">The enum value</param>
+    /// <returns>The display name of the enum value</returns>
+    private static string GetDisplayName<TEntry>(this TEntry enumValue) where TEntry : Enum
+    {
+        var displayName = enumValue.GetType()
+            .GetMember(enumValue.ToString())
+            .FirstOrDefault()?
+            .GetCustomAttribute<DisplayAttribute>()?
+            .GetName();
+
+        return displayName ?? enumValue.ToString();
     }
 }

--- a/Flashcards/Interfaces/View/Factory/IMenuEntriesInitializer.cs
+++ b/Flashcards/Interfaces/View/Factory/IMenuEntriesInitializer.cs
@@ -12,7 +12,6 @@ internal interface IMenuEntriesInitializer<TMenu> where TMenu : Enum
     /// Initializes the entries for a specific menu.
     /// </summary>
     /// <typeparam name="TMenu">The type of menu entries.</typeparam>
-    /// <param name="menuCommandFactory">The menu command factory.</param>
     /// <returns>A dictionary mapping menu entries to command functions.</returns>
-    Dictionary<TMenu, Func<ICommand>> InitializeEntries(IMenuCommandFactory<TMenu> menuCommandFactory);
+    Dictionary<TMenu, Func<ICommand>> InitializeEntries();
 }

--- a/Flashcards/View/Factory/EntriesInitializers/FlashcardsMenuEntriesInitializer.cs
+++ b/Flashcards/View/Factory/EntriesInitializers/FlashcardsMenuEntriesInitializer.cs
@@ -31,7 +31,7 @@ internal class FlashcardsMenuEntriesInitializer : IMenuEntriesInitializer<Flashc
         _stackEntryHandler = stackEntryHandler;
     }
 
-    public Dictionary<FlashcardEntries, Func<ICommand>> InitializeEntries(IMenuCommandFactory<FlashcardEntries> flashcardsMenuCommandFactory) =>
+    public Dictionary<FlashcardEntries, Func<ICommand>> InitializeEntries() =>
         new()
         {
             { FlashcardEntries.ChooseFlashcard, () => new ViewFlashcards(

--- a/Flashcards/View/Factory/EntriesInitializers/MainMenuEntriesInitializer.cs
+++ b/Flashcards/View/Factory/EntriesInitializers/MainMenuEntriesInitializer.cs
@@ -43,7 +43,7 @@ internal class MainMenuEntriesInitializer : IMenuEntriesInitializer<MainMenuEntr
         _stackEntryHandler = stackEntryHandler;
     }
 
-    public Dictionary<MainMenuEntries, Func<ICommand>> InitializeEntries(IMenuCommandFactory<MainMenuEntries> commandFactory) =>
+    public Dictionary<MainMenuEntries, Func<ICommand>> InitializeEntries() =>
         new()
         {
             { MainMenuEntries.StartStudySession, () => 

--- a/Flashcards/View/Factory/EntriesInitializers/ReportsMenuEntriesInitializer.cs
+++ b/Flashcards/View/Factory/EntriesInitializers/ReportsMenuEntriesInitializer.cs
@@ -28,8 +28,7 @@ internal class ReportsMenuEntriesInitializer : IMenuEntriesInitializer<ReportsMe
         _yearEntryHandler = yearEntryHandler;
     }
 
-    public Dictionary<ReportsMenuEntries, Func<ICommand>> InitializeEntries(
-        IMenuCommandFactory<ReportsMenuEntries> menuCommandFactory) =>
+    public Dictionary<ReportsMenuEntries, Func<ICommand>> InitializeEntries() =>
         new()
         {
             { ReportsMenuEntries.FullReport, () => new FullReport(

--- a/Flashcards/View/Factory/EntriesInitializers/StacksMenuEntriesInitializer.cs
+++ b/Flashcards/View/Factory/EntriesInitializers/StacksMenuEntriesInitializer.cs
@@ -26,7 +26,7 @@ internal class StacksMenuEntriesInitializer : IMenuEntriesInitializer<StackMenuE
         _stackEntryHandler = stackEntryHandler;
     }
 
-    public Dictionary<StackMenuEntries, Func<ICommand>> InitializeEntries(IMenuCommandFactory<StackMenuEntries> menuCommandFactory) =>
+    public Dictionary<StackMenuEntries, Func<ICommand>> InitializeEntries() =>
         new()
         {
             { StackMenuEntries.AddStack, () => new AddStack(_stacksRepository) },

--- a/Flashcards/View/Factory/MenuCommandFactory.cs
+++ b/Flashcards/View/Factory/MenuCommandFactory.cs
@@ -10,13 +10,10 @@ namespace Flashcards.View.Factory;
 internal class MenuCommandFactory<TMenu> : IMenuCommandFactory<TMenu> where TMenu : Enum
 {
     private readonly Dictionary<TMenu, Func<ICommand>> _entriesFactory;
-
-    /// The MenuCommandFactory class is responsible for creating an instance of the ICommand interface based on the provided menu entry.
-    /// @param <TMenu> The type of the menu entry enum.
-    /// /
+    
     public MenuCommandFactory(IMenuEntriesInitializer<TMenu> entriesInitializer)
     {
-        _entriesFactory = entriesInitializer.InitializeEntries(this);
+        _entriesFactory = entriesInitializer.InitializeEntries();
     }
 
     /// <summary>


### PR DESCRIPTION
Refactor multiple initializers to simplify methods by removing unused `IMenuCommandFactory` parameters. This change improves code clarity without affecting functionality.